### PR TITLE
Add whitelabel brand.

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -21,7 +21,9 @@ h3 {
 }
 
 .demo-card--dark {
-	background: oColorsGetPaletteColor('slate');
+	// @todo figure out how to brand demos without adding brand variables just for demos.
+	// https://github.com/Financial-Times/o-brand/issues/31
+	background: if($o-brand == 'whitelabel', oColorsGetPaletteColor('black'), oColorsGetPaletteColor('slate'));
 }
 
 .demo-toggle {

--- a/origami.json
+++ b/origami.json
@@ -6,7 +6,8 @@
 	"origamiVersion": 1,
 	"brands": [
 		"master",
-		"internal"
+		"internal",
+		"whitelabel"
 	],
 	"support": "https://github.com/Financial-Times/o-loading/issues",
 	"supportContact": {

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -39,3 +39,18 @@
 		'dark'
 	)
 ));
+
+@include oBrandDefine('o-loading', 'whitelabel', (
+	'variables': (
+		'light': (
+			default-color: oColorsGetPaletteColor('white')
+		),
+		'dark': (
+			default-color: oColorsGetPaletteColor('black')
+		)
+	),
+	'supports-variants': (
+		'light',
+		'dark'
+	)
+));


### PR DESCRIPTION
This fixes `o-forms` build failures for the whitelabel brand by adding whitelabel support to `o-loading`.

[o-brand@v3.1](https://github.com/Financial-Times/o-brand/pull/27) allowed components to not set the default master brand, and removed the fallback behaviour.  

This means any dependancy of a branded component must either be un-branded or also support the same brands.