### PR TITLE
Add `oLoadingCustomize` for whitelabel users.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,17 @@
 
 The `$o-loading-themes` variable is now private. If you are a whitelabel brand user and would like to customise the colours of `o-loading`, use the `oLoadingCustomize` mixin instead. See [o-loading Sassdoc](https://registry.origami.ft.com/components/o-loading/sassdoc?brand=whitelabel) for more details.
 
+The `$o-loading-sizes` is also now private. If your project uses this to configure which sizes of `o-loading` to output, use the `oLoading` mixin instead, e.g.
+```scss
+@include oLoading($opts: (
+	'themes': ('light'),
+	'sizes': ('medium', 'large')
+));
+```
+If your project uses `$o-loading-sizes` for any other reason, e.g. to customise the dimensions of `o-loading`, please contact the Origami team.
+
+Finally the `$o-loading-animation-keyframes` variable is now private and should not be used.
+
 ### Migrating from 2 to 3
 
 V3 changes the internal structure of `o-loading`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,10 @@
 ## Migration Guide
 
-### Migrating from 2.X.X to 3.X.X
+### Migrating from 3 to 4
+
+The `$o-loading-themes` mixin is now private. If you are a whitelabel brand user and would like to customise the colours of `o-loading`, use the `oLoadingCustomize` mixin instead. See [o-loading Sassdoc](https://registry.origami.ft.com/components/o-loading/sassdoc?brand=whitelabel) for more details.
+
+### Migrating from 2 to 3
 
 V3 changes the internal structure of `o-loading`.
 
@@ -32,6 +36,6 @@ If you can't use `o-loading` classes, you can add styles to a specific element b
 
 There is also a new size available in `o-loading`, namely `mini`.
 
-### Migrating from 1.X.X to 2.X.X
+### Migrating from 1 to 2
 
 V1 -> V2 introduces the new majors of o-colors. Updating to this new version will mean updating any other components that you have which are using o-colors. There are no other breaking changes in this release.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 ### Migrating from 3 to 4
 
-The `$o-loading-themes` mixin is now private. If you are a whitelabel brand user and would like to customise the colours of `o-loading`, use the `oLoadingCustomize` mixin instead. See [o-loading Sassdoc](https://registry.origami.ft.com/components/o-loading/sassdoc?brand=whitelabel) for more details.
+The `$o-loading-themes` variable is now private. If you are a whitelabel brand user and would like to customise the colours of `o-loading`, use the `oLoadingCustomize` mixin instead. See [o-loading Sassdoc](https://registry.origami.ft.com/components/o-loading/sassdoc?brand=whitelabel) for more details.
 
 ### Migrating from 2 to 3
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ If you need to build a loading spinner into a component, for example, you can us
 
 State | Major Version | Last Minor Release | Migration guide |
 :---: | :---: | :---: | :---:
-✨ active | 3 | N/A | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
-⚠ maintained | 2 | 2.3 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+✨ active | 4 | N/A | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+⚠ maintained | 3 | 3.1| [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+╳ deprecated | 2 | 2.3 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
 ╳ deprecated | 1 | 1.0 | N/A |
 
 ## Contact

--- a/main.scss
+++ b/main.scss
@@ -30,7 +30,7 @@
 
 	@each $size in $sizes {
 		.o-loading--#{$size} {
-			@include _oLoadingSize(map-get($o-loading-sizes, $size));
+			@include _oLoadingSize(map-get($_o-loading-sizes, $size));
 		}
 	}
 }

--- a/main.scss
+++ b/main.scss
@@ -24,7 +24,7 @@
 
 	@each $theme in $themes {
 		.o-loading--#{$theme} {
-			@include _oLoadingColor(map-get($o-loading-themes, $theme));
+			@include _oLoadingColor($theme);
 		}
 	}
 
@@ -36,7 +36,6 @@
 }
 
 @if $o-loading-is-silent == false {
-
 	@include oLoading();
 
 	$o-loading-is-silent: true !global;

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -10,6 +10,30 @@
 	@return oBrandSupportsVariant($component: 'o-loading', $variant: $variant);
 }
 
+/// Helper for `whitelabel` variable customisation
+/// @brand whitelabel
+/// @param {Map} $variables - Brand variables to customise
+/// @access public
+/// @example scss
+///		@include oLoadingCustomize((
+///			'light': (
+///				default-color: hotpink
+///			),
+///			'dark': (
+///				default-color: black
+///			)
+///		))
+@mixin oLoadingCustomize($variables) {
+	$keys: map-keys($variables);
+	@each $key in $keys {
+		@if($key != 'dark' and $key != 'light')	{
+			@error 'Only light and dark o-loading variants may be customised. Found "#{$key}".';
+		}
+	}
+
+	@include oBrandCustomize('o-loading', $variables);
+}
+
 @include oBrandDefine('o-loading', 'master', (
 	'variables': (
 		'light': (

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -7,7 +7,7 @@
 /// Outputs the keyframe animation definition
 @mixin _oLoadingAnimationKeyframes {
 	@at-root {
-		@if not $o-loading-animation-keyframes {
+		@if not $_o-loading-animation-keyframes {
 			@keyframes o-loading-spinner {
 				0% {
 					transform: rotate(0deg);
@@ -17,7 +17,7 @@
 				}
 			}
 
-			$o-loading-animation-keyframes: true !global;
+			$_o-loading-animation-keyframes: true !global;
 		}
 	}
 }
@@ -50,7 +50,7 @@
 /// @access private
 @mixin _oLoadingSize($name) {
 	@if type-of($name) == 'string' {
-		$name: map-get($o-loading-sizes, $name);
+		$name: map-get($_o-loading-sizes, $name);
 
 		@if not $name {
 			@warn "Size: '#{$name}' not found for o-loading";

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -29,17 +29,14 @@
 	border-radius: 50%;
 	animation: o-loading-spinner 1s infinite linear;
 }
-/// Color variation for a loading indicator
+/// Styles for a color variation for a loading indicator.
 ///
-/// @param {String|Color} $color
+/// @param {String} $theme
 /// @access private
-@mixin _oLoadingColor($color) {
-	@if type-of($color) == 'string' {
-		$color: map-get($o-loading-themes, $color);
-
-		@if not $color {
-			@warn "Color: '#{$color}' not found for o-loading";
-		}
+@mixin _oLoadingColor($theme) {
+	$color: _oLoadingGet('default-color', $from: $theme);
+	@if(not $color) {
+		@error 'No color found for o-loading theme "#{$theme}".';
 	}
 
 	border-style: solid;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -17,7 +17,7 @@ $o-loading-animation-keyframes: false !default;
 /// Predefined themes
 ///
 /// @type Map
-$o-loading-themes: (
+$_o-loading-themes: (
 	'light': _oLoadingGet('default-color', $from: 'light'),
 	'dark': _oLoadingGet('default-color', $from: 'dark')
 );

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -10,12 +10,12 @@
 $o-loading-is-silent: true !default;
 
 /// Keyframe animation output once flag
-/// @private
+/// @access private
 /// @type Boolean
-$o-loading-animation-keyframes: false !default;
+$_o-loading-animation-keyframes: false !default;
 
 /// Predefined themes
-///
+/// @access private
 /// @type Map
 $_o-loading-themes: (
 	'light': _oLoadingGet('default-color', $from: 'light'),
@@ -23,9 +23,9 @@ $_o-loading-themes: (
 );
 
 /// Predefined sizes
-///
+/// @access private
 /// @type Map
-$o-loading-sizes: (
+$_o-loading-sizes: (
 	'mini': ('size': 12px, 'border': 2px),
 	'small': ('size': 20px, 'border': 3px),
 	'medium': ('size': 28px, 'border': 4px),

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,0 +1,80 @@
+
+@include describe('oLoading') {
+	@include it('outputs both the light and dark variants by default') {
+		// assert the light variant is output
+		@include assert() {
+			@include output($selector: false)  {
+				@include oLoading();
+			};
+
+			@include contains($selector: false) {
+      			.o-loading--light {
+      			  border-top-color: #ffffff;
+      			}
+			};
+		};
+
+		// assert the dark variant is output
+		@include assert() {
+			@include output($selector: false)  {
+				// output o-loading.
+				@include oLoading();
+			};
+
+			@include contains($selector: false) {
+      			.o-loading--dark {
+      			  border-top-color: #33302e;
+      			}
+			};
+		};
+	};
+};
+
+
+@include describe('oLoadingCustomize') {
+	@include it('sets the light and dark variant colours') {
+		// Set o-brand to whitelabel for `oLoadingCustomize` test.
+		$o-brand-stash: $o-brand;
+		$o-brand: 'whitelabel' !global;
+
+		// Customise o-loading.
+		@include oLoadingCustomize((
+			'light': (
+				default-color: hotpink
+			),
+			'dark': (
+				default-color: black
+			)
+		));
+
+		// assert the light variant is customised
+		@include assert() {
+			@include output($selector: false)  {
+				@include oLoading();
+			};
+
+			@include contains($selector: false) {
+      			.o-loading--light {
+      			  border-top-color: hotpink;
+      			}
+			};
+		};
+
+		// assert the dark variant is customised
+		@include assert() {
+			@include output($selector: false)  {
+				// output o-loading.
+				@include oLoading();
+			};
+
+			@include contains($selector: false) {
+      			.o-loading--dark {
+      			  border-top-color: black;
+      			}
+			};
+		};
+
+		// Restore default brand
+		$o-brand: $o-brand-stash !global;
+	};
+};

--- a/test/scss/index.test.scss
+++ b/test/scss/index.test.scss
@@ -1,0 +1,5 @@
+@import 'true';
+
+@import '../../main';
+
+@import 'mixins.test';


### PR DESCRIPTION
- Add `oLoadingCustomize` for whitelabel users.
- Makes the variables `$o-loading-themes`, `$o-loading-sizes`, and `$o-loading-animation-keyframes` private.